### PR TITLE
#12 - Implementar rota que permita listar todos os pokémons que estão a venda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-* [#20](https://github.com/afmireski/garchop-api/issues/20) - Implementar rota que permita listar todos os pokémons que estão a venda
+* [#20](https://github.com/afmireski/garchop-api/issues/20) - Implementar rota que exiba as informações detalhadas de um Pokémon
 * [#9](https://github.com/afmireski/garchop-api/issues/9) - Implementar rota que permita o cadastro de um novo pokémon
     * Criado novos recursos relacionados a pokemons e tipo de pokemon
 * [#4](https://github.com/afmireski/garchop-api/issues/4) - Implementar rota que permita a atualização das informações de um usuário

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* [#12](https://github.com/afmireski/garchop-api/issues/12) - Implementar rota que permita listar todos os pokémons que estão a venda
 * [#20](https://github.com/afmireski/garchop-api/issues/20) - Implementar rota que exiba as informações detalhadas de um Pokémon
 * [#9](https://github.com/afmireski/garchop-api/issues/9) - Implementar rota que permita o cadastro de um novo pokémon
     * Criado novos recursos relacionados a pokemons e tipo de pokemon

--- a/internal/adapters/supabase-pokemon-repository.go
+++ b/internal/adapters/supabase-pokemon-repository.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	supabase "github.com/nedpals/supabase-go"
 
@@ -21,15 +22,17 @@ func NewSupabasePokemonRepository(client *supabase.Client) *SupabasePokemonRepos
 }
 
 func serializeToModel(supabaseData myTypes.AnyMap) (*models.PokemonModel, error) {
-	jsonData, err := json.Marshal(supabaseData); if err != nil {
+	jsonData, err := json.Marshal(supabaseData)
+	if err != nil {
 		return nil, err
 	}
 
 	var modelData models.PokemonModel
-	err = json.Unmarshal(jsonData, &modelData); if err != nil {
+	err = json.Unmarshal(jsonData, &modelData)
+	if err != nil {
 		return nil, err
 	}
-	
+
 	return &modelData, nil
 }
 
@@ -68,7 +71,8 @@ func serializeManyToModel(supabaseData []myTypes.AnyMap) ([]models.PokemonModel,
 func (r *SupabasePokemonRepository) Create(input myTypes.CreatePokemonInput) (string, error) {
 	var supabaseData []myTypes.AnyMap
 
-	err := r.client.DB.From("pokemons").Insert(input).Execute(&supabaseData); if err != nil {
+	err := r.client.DB.From("pokemons").Insert(input).Execute(&supabaseData)
+	if err != nil {
 		return "", err
 	}
 
@@ -77,46 +81,52 @@ func (r *SupabasePokemonRepository) Create(input myTypes.CreatePokemonInput) (st
 
 type createPriceInput struct {
 	PokemonId string `json:"pokemon_id"`
-	Value int `json:"value"`
+	Value     int    `json:"value"`
 }
 type createStockInput struct {
 	PokemonId string `json:"pokemon_id"`
-	Quantity int `json:"quantity"`
+	Quantity  int    `json:"quantity"`
 }
 type createPokemonTypeInput struct {
 	PokemonId string `json:"pokemon_id"`
-	TypeId string `json:"type_id"`
+	TypeId    string `json:"type_id"`
 }
+
 func (r *SupabasePokemonRepository) Registry(input myTypes.RegistryPokemonInput) (string, error) {
-	pokemonId, err := r.Create(input.CreatePokemonInput); if err != nil {
+	pokemonId, err := r.Create(input.CreatePokemonInput)
+	if err != nil {
 		return "", err
 	}
 
 	var supabaseData []myTypes.AnyMap
-	
+
 	priceInput := createPriceInput{
 		PokemonId: pokemonId,
-		Value: input.Price,
+		Value:     input.Price,
 	}
-	err = r.client.DB.From("prices").Insert(priceInput).Execute(&supabaseData); if err != nil {
+	err = r.client.DB.From("prices").Insert(priceInput).Execute(&supabaseData)
+	if err != nil {
 		return "", err
 	}
 
 	stockInput := createStockInput{
 		PokemonId: pokemonId,
-		Quantity: input.InitialStock,
+		Quantity:  input.InitialStock,
 	}
-	err = r.client.DB.From("stocks").Insert(stockInput).Execute(&supabaseData); if err != nil {
+	err = r.client.DB.From("stocks").Insert(stockInput).Execute(&supabaseData)
+	if err != nil {
 		return "", err
 	}
 
 	for _, typeId := range input.Types {
 		err = r.client.DB.From("pokemon_types").Insert(createPokemonTypeInput{
 			PokemonId: pokemonId,
-			TypeId: typeId,
-		}).Execute(&supabaseData); if err != nil {
+			TypeId:    typeId,
+		}).Execute(&supabaseData)
+		if err != nil {
 			return "", err
-		}; if err != nil {
+		}
+		if err != nil {
 			return "", err
 		}
 	}
@@ -127,7 +137,7 @@ func (r *SupabasePokemonRepository) Registry(input myTypes.RegistryPokemonInput)
 func (r *SupabasePokemonRepository) FindById(id string, where myTypes.Where) (*models.PokemonModel, error) {
 	var supabaseData myTypes.AnyMap
 
-	query := r.client.DB.From("pokemons").Select("*", "prices (*)", "stocks (*)", "pokemon_types (*, types (*))", "tiers (*)").Single().Eq("id", id);
+	query := r.client.DB.From("pokemons").Select("*", "prices (*)", "stocks (*)", "pokemon_types (*, types (*))", "tiers (*)").Single().Eq("id", id)
 
 	if len(where) > 0 {
 		for column, filter := range where {
@@ -136,8 +146,9 @@ func (r *SupabasePokemonRepository) FindById(id string, where myTypes.Where) (*m
 			}
 		}
 	}
-	
-	err := query.Execute(&supabaseData); if err != nil {
+
+	err := query.Execute(&supabaseData)
+	if err != nil {
 		if strings.Contains(err.Error(), "PGRST116") { // resource not found
 			return nil, nil
 		}
@@ -151,7 +162,15 @@ func (r *SupabasePokemonRepository) FindById(id string, where myTypes.Where) (*m
 func (r *SupabasePokemonRepository) FindAll(where myTypes.Where) ([]models.PokemonModel, error) {
 	var supabaseData []myTypes.AnyMap
 
-	query := r.client.DB.From("pokemons").Select("*", "prices (*)", "stocks (*)", "pokemon_types (*, types (*))", "tiers (*)")
+	query := r.client.DB.From("pokemons").Select("*", "prices (*)", "stocks (*)", "pokemon_types (*, types (*))", "tiers (*)").Is("deleted_at", "null")
+
+	if len(where) > 0 {
+		for column, filter := range where {
+			for operator, criteria := range filter {
+				query = query.Filter(column, operator, criteria)
+			}
+		}
+	}
 
 	err := query.Execute(&supabaseData)
 
@@ -170,7 +189,3 @@ func (r *SupabasePokemonRepository) FindAll(where myTypes.Where) ([]models.Pokem
 func (r *SupabasePokemonRepository) Update(id string, input myTypes.AnyMap, where myTypes.Where) (myTypes.Any, error) {
 	panic("method not implemented")
 }
-
-
-
-

--- a/internal/adapters/supabase-pokemon-repository.go
+++ b/internal/adapters/supabase-pokemon-repository.go
@@ -33,6 +33,38 @@ func serializeToModel(supabaseData myTypes.AnyMap) (*models.PokemonModel, error)
 	return &modelData, nil
 }
 
+func serializeManyToModel(supabaseData []myTypes.AnyMap) ([]models.PokemonModel, error) {
+	timeLayout := "2006-01-02T15:04:05.999999-07:00"
+
+	for _, d := range supabaseData {
+		for key, value := range d {
+			if strings.Contains(key, "deleted_at") {
+				if strValue, ok := value.(string); ok {
+					if len(strValue) == 0 {
+						tmp := time.Time{}
+						d[key] = tmp.Format(timeLayout)
+					}
+				}
+			}
+		}
+	}
+
+	jsonData, err := json.Marshal(supabaseData)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var result []models.PokemonModel
+	err = json.Unmarshal(jsonData, &result)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (r *SupabasePokemonRepository) Create(input myTypes.CreatePokemonInput) (string, error) {
 	var supabaseData []myTypes.AnyMap
 

--- a/internal/adapters/supabase-pokemon-repository.go
+++ b/internal/adapters/supabase-pokemon-repository.go
@@ -117,7 +117,22 @@ func (r *SupabasePokemonRepository) FindById(id string, where myTypes.Where) (*m
 }
 
 func (r *SupabasePokemonRepository) FindAll(where myTypes.Where) ([]myTypes.Any, error) {
-	panic("method not implemented")
+	var supabaseData []myTypes.AnyMap
+
+	query := r.client.DB.From("pokemons").Select("*", "prices (*)", "stocks (*)", "pokemon_types (*, types (*))", "tiers (*)")
+
+	err := query.Execute(&supabaseData)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "PGRST116") { // resource not found
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return serializeManyToModel(supabaseData)
+
 }
 
 func (r *SupabasePokemonRepository) Update(id string, input myTypes.AnyMap, where myTypes.Where) (myTypes.Any, error) {

--- a/internal/adapters/supabase-pokemon-repository.go
+++ b/internal/adapters/supabase-pokemon-repository.go
@@ -148,7 +148,7 @@ func (r *SupabasePokemonRepository) FindById(id string, where myTypes.Where) (*m
 	return serializeToModel(supabaseData)
 }
 
-func (r *SupabasePokemonRepository) FindAll(where myTypes.Where) ([]myTypes.Any, error) {
+func (r *SupabasePokemonRepository) FindAll(where myTypes.Where) ([]models.PokemonModel, error) {
 	var supabaseData []myTypes.AnyMap
 
 	query := r.client.DB.From("pokemons").Select("*", "prices (*)", "stocks (*)", "pokemon_types (*, types (*))", "tiers (*)")

--- a/internal/entities/pokemon.go
+++ b/internal/entities/pokemon.go
@@ -1,23 +1,24 @@
 package entities
 
-import "github.com/afmireski/garchop-api/internal/models"
-
+import (
+	"github.com/afmireski/garchop-api/internal/models"
+)
 
 type Pokemon struct {
-	Id string `json:"id"`
-	ReferenceId uint `json:"reference_id"`
-	Name string `json:"name"`
-	Weight uint `json:"weight"`
-	Height uint `json:"height"`
-	ImageUrl string `json:"image_url"`
-	Experience uint `json:"experience"`
-	Types []PokemonType `json:"types"`
-	Tier Tier `json:"tier"`
+	Id          string        `json:"id"`
+	ReferenceId uint          `json:"reference_id"`
+	Name        string        `json:"name"`
+	Weight      uint          `json:"weight"`
+	Height      uint          `json:"height"`
+	ImageUrl    string        `json:"image_url"`
+	Experience  uint          `json:"experience"`
+	Types       []PokemonType `json:"types"`
+	Tier        Tier          `json:"tier"`
 }
 
 type PokemonProduct struct {
 	Pokemon
-	Price uint `json:"price"`
+	Price   uint `json:"price"`
 	InStock uint `json:"in_stock"`
 }
 
@@ -29,25 +30,37 @@ func BuildPokemonProductFromModel(model models.PokemonModel) *PokemonProduct {
 	}
 
 	tier := Tier{
-		Id: model.Tier.Id,
-		Name: model.Tier.Name,
+		Id:                model.Tier.Id,
+		Name:              model.Tier.Name,
 		MinimalExperience: model.Tier.MinimalExperience,
-		LimitExperience: model.Tier.LimitExperience,
+		LimitExperience:   model.Tier.LimitExperience,
 	}
 
 	return &PokemonProduct{
 		Pokemon: Pokemon{
-			Id: model.Id,
+			Id:          model.Id,
 			ReferenceId: model.ReferenceId,
-			Name: model.Name,
-			Weight: model.Weight,
-			Height: model.Height,
-			ImageUrl: model.ImageUrl,
-			Experience: model.Experience,
-			Types: types,
-			Tier: tier,
+			Name:        model.Name,
+			Weight:      model.Weight,
+			Height:      model.Height,
+			ImageUrl:    model.ImageUrl,
+			Experience:  model.Experience,
+			Types:       types,
+			Tier:        tier,
 		},
-		Price: model.Prices[0].Value,
+		Price:   model.Prices[0].Value,
 		InStock: model.Stock.Quantity,
 	}
+}
+
+func BuildManyPokemonProductFromModel(data []models.PokemonModel) []PokemonProduct {
+	var result []PokemonProduct
+
+	for _, val := range data {
+		var tmp *PokemonProduct
+		tmp = BuildPokemonProductFromModel(val)
+		result = append(result, *tmp)
+	}
+
+	return result
 }

--- a/internal/ports/pokemon-repository-port.go
+++ b/internal/ports/pokemon-repository-port.go
@@ -12,7 +12,7 @@ type PokemonRepositoryPort interface {
 
 	FindById(id string, where myTypes.Where) (*models.PokemonModel, error)
 
-	FindAll(where myTypes.Where) ([]myTypes.Any, error)
+	FindAll(where myTypes.Where) ([]models.PokemonModel, error)
 
 	Update(id string, input myTypes.AnyMap, where myTypes.Where) (myTypes.Any, error)
 }

--- a/internal/services/pokemon-service.go
+++ b/internal/services/pokemon-service.go
@@ -184,3 +184,7 @@ func (s *PokemonService) GetPokemonById(id string) (*entities.PokemonProduct, *c
 
 	return entities.BuildPokemonProductFromModel(*repositoryData), nil
 }
+
+func (s *PokemonService) GetAvailablePokemons() ([]entities.PokemonProduct, *customErrors.InternalError) {
+	panic("method not implemented")
+}

--- a/internal/services/pokemon-service.go
+++ b/internal/services/pokemon-service.go
@@ -171,12 +171,13 @@ func (s *PokemonService) GetPokemonById(id string) (*entities.PokemonProduct, *c
 	if !validators.IsValidUuid(id) {
 		return nil, customErrors.NewInternalError("invalid id", 400, []string{"the id must be a valid uuid"})
 	}
-	
+
 	where := myTypes.Where{
 		"deleted_at": map[string]string{"is": "null"},
 	}
 
-	repositoryData, err := s.repository.FindById(id, where); if err != nil {
+	repositoryData, err := s.repository.FindById(id, where)
+	if err != nil {
 		return nil, customErrors.NewInternalError("a failure occurred when try to find the pokemon", 500, []string{err.Error()})
 	} else if repositoryData == nil {
 		return nil, customErrors.NewInternalError("pokemon not found", 404, []string{})
@@ -186,5 +187,13 @@ func (s *PokemonService) GetPokemonById(id string) (*entities.PokemonProduct, *c
 }
 
 func (s *PokemonService) GetAvailablePokemons() ([]entities.PokemonProduct, *customErrors.InternalError) {
-	panic("method not implemented")
+	repositoryData, err := s.repository.FindAll(nil)
+
+	if err != nil {
+		return nil, customErrors.NewInternalError("a failure occurred when try to find the pokemon", 500, []string{err.Error()})
+	} else if repositoryData == nil {
+		return nil, customErrors.NewInternalError("pokemon not found", 404, []string{})
+	}
+
+	return entities.BuildManyPokemonProductFromModel(repositoryData), nil
 }

--- a/internal/web/controllers/pokemon-controller.go
+++ b/internal/web/controllers/pokemon-controller.go
@@ -41,6 +41,20 @@ func (c *PokemonController) RegistryNewPokemon(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusCreated)
 }
 
+func (c *PokemonController) GetAllPokemons(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	response, err := c.service.GetAvailablePokemons()
+	if err != nil {
+		w.WriteHeader(err.HttpCode)
+		json.NewEncoder(w).Encode(err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
 func (c *PokemonController) GetPokemonById(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/internal/web/controllers/pokemon-controller.go
+++ b/internal/web/controllers/pokemon-controller.go
@@ -41,7 +41,7 @@ func (c *PokemonController) RegistryNewPokemon(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusCreated)
 }
 
-func (c *PokemonController) GetAllPokemons(w http.ResponseWriter, r *http.Request) {
+func (c *PokemonController) GetPokemonById(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	idParam := chi.URLParam(r, "id")

--- a/internal/web/routers/pokemon-router.go
+++ b/internal/web/routers/pokemon-router.go
@@ -8,4 +8,5 @@ import (
 func SetupPokemonRouter(r chi.Router, controller *controllers.PokemonController) {
 	r.Post("/pokemon/new", controller.RegistryNewPokemon)
 	r.Get("/pokemon/{id}", controller.GetPokemonById)
+	r.Get("/pokemon", controller.GetAllPokemons)
 }

--- a/internal/web/routers/pokemon-router.go
+++ b/internal/web/routers/pokemon-router.go
@@ -7,5 +7,5 @@ import (
 
 func SetupPokemonRouter(r chi.Router, controller *controllers.PokemonController) {
 	r.Post("/pokemon/new", controller.RegistryNewPokemon)
-	r.Get("/pokemon/{id}", controller.GetAllPokemons)
+	r.Get("/pokemon/{id}", controller.GetPokemonById)
 }


### PR DESCRIPTION
## Descrição
Implementar rota que permita listar todos os pokémons que estão a venda.


## Contexto
- **motivação:** Implementar rota que permita listar todos os pokémons que estão a venda.

closes #12 

<!-- Providência qualquer detalhe extra que achar importante -->

## Como testar
1. Requisite para a rota: `GET /pokemon`

### Escritor
- [x] A rota foi mapeada corretamente.
- [x] Caso ocorra alguma falha inesperada durante a busca, lança a exceção 500.
- [x] Caso não ocorra exceções, retorna as informações dos Pokémons disponíveis com código 200.

### Tester
- [x] A rota foi mapeada corretamente.
- [x] Caso ocorra alguma falha inesperada durante a busca, lança a exceção 500.
- [x] Caso não ocorra exceções, retorna as informações dos Pokémons disponíveis com código 200.

## Natureza da alteração
<!-- Indica o tipo de alteração que foi feita -->
- [x] Nova Feature.
- [ ] Correção de BUG.
- [ ] Refatoração de Código.