### PR TITLE
#56 - Trazer dados de Status do Usuário na hora de listar o perfil do usuário

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* [#56](https://github.com/afmireski/garchop-api/issues/56) - Trazer dados de Status do Usuário na hora de listar o perfil do usuário
 * [#45](https://github.com/afmireski/garchop-api/issues/45) - Implementar listagem do histórico de compras do usuário
 * [#50](https://github.com/afmireski/garchop-api/issues/50) - Criar `UserStats` no momento do cadastro do usuário
 * [#39](https://github.com/afmireski/garchop-api/issues/39) - Implementar remoção de um item do carrinho de compras

--- a/internal/adapters/supabase-users-repository.go
+++ b/internal/adapters/supabase-users-repository.go
@@ -24,7 +24,49 @@ func NewSupabaseUsersRepository(client *supabase.Client) *SupabaseUsersRepositor
 	}
 }
 
-func serializeMany(data []map[string]string) ([]models.UserModel, error) {
+func (r *SupabaseUsersRepository) fixBirthDate(rawBirthDate string) string {
+	timeLayout := "2006-01-02T15:04:05.999999-03:00"
+	birthDate, _ := time.Parse("2006-01-02", rawBirthDate)
+	return birthDate.Format(timeLayout)
+}
+
+func (r *SupabaseUsersRepository) serializeSupabaseDataToModel(supabaseData myTypes.AnyMap) (*models.UserModel, error) {
+	supabaseData["birth_date"] = r.fixBirthDate(supabaseData["birth_date"].(string))
+
+	jsonData, err := json.Marshal(supabaseData)
+	if err != nil {
+		return nil, err
+	}
+
+	var modelData models.UserModel
+	err = json.Unmarshal(jsonData, &modelData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &modelData, nil
+}
+
+func (r *SupabaseUsersRepository) serializeManySupabaseDataToModel(supabaseData []myTypes.AnyMap) ([]models.UserModel, error) {
+	for i, element := range supabaseData {
+		supabaseData[i]["birth_date"] = r.fixBirthDate(element["birth_date"].(string))
+	}	
+
+	jsonData, err := json.Marshal(supabaseData)
+	if err != nil {
+		return nil, err
+	}
+
+	var modelData []models.UserModel
+	err = json.Unmarshal(jsonData, &modelData)
+	if err != nil {
+		return nil, err
+	}
+
+	return modelData, nil
+}
+
+func (s *SupabaseUsersRepository) serializeMany(data []map[string]string) ([]models.UserModel, error) {
 	timeLayout := "2006-01-02T15:04:05.999999-07:00"
 
 	for _, d := range data {
@@ -53,37 +95,6 @@ func serializeMany(data []map[string]string) ([]models.UserModel, error) {
 	json.Unmarshal(jsonData, &result)
 
 	return result, nil
-}
-
-func mapToUserModel(data map[string]interface{}) (*models.UserModel, error) {
-	birthDate, _ := time.Parse("2006-01-02", data["birth_date"].(string))
-
-	createdAt, _ := time.Parse("2006-01-02T15:04:05.999999999Z07:00", data["created_at"].(string))
-
-	updatedAt, _ := time.Parse("2006-01-02T15:04:05.999999999Z07:00", data["updated_at"].(string))
-
-	var deletedAt time.Time
-	if deletedAtString, ok := data["deleted_at"].(string); ok {
-		deletedAt, _ = time.Parse("2006-01-02T15:04:05.999999999Z07:00", deletedAtString)
-	}
-
-	var role models.UserModelRoleEnum
-	if data["role"] == "client" {
-		role = models.Client
-	} else {
-		role = models.Admin
-	}
-
-	return models.NewUserModel(
-		data["id"].(string),
-		data["name"].(string),
-		data["email"].(string),
-		data["phone"].(string),
-		birthDate,
-		role,
-		createdAt,
-		updatedAt,
-		deletedAt), nil
 }
 
 type CreateInput struct {
@@ -145,11 +156,11 @@ func (r *SupabaseUsersRepository) FindById(id string, where myTypes.Where) (*mod
 		return nil, err
 	}
 
-	return mapToUserModel(supabaseData)
+	return r.serializeSupabaseDataToModel(supabaseData)
 }
 
 func (r *SupabaseUsersRepository) FindAll(where myTypes.Where) ([]models.UserModel, error) {
-	var supabaseData []map[string]string
+	var supabaseData []myTypes.AnyMap
 
 	query := r.client.DB.From("users").Select("*").Is("deleted_at", "null")
 
@@ -171,16 +182,11 @@ func (r *SupabaseUsersRepository) FindAll(where myTypes.Where) ([]models.UserMod
 		return nil, nil
 	}
 
-	result, err := serializeMany(supabaseData)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return r.serializeManySupabaseDataToModel(supabaseData)
 }
 
 func (r *SupabaseUsersRepository) Update(id string, input myTypes.AnyMap, where myTypes.Where) (*models.UserModel, error) {
-	var supabaseData []map[string]string
+	var supabaseData []myTypes.AnyMap
 	query := r.client.DB.From("users").Update(input).Eq("id", id)
 	if len(where) > 0 {
 		for column, filter := range where {
@@ -199,7 +205,7 @@ func (r *SupabaseUsersRepository) Update(id string, input myTypes.AnyMap, where 
 		return nil, nil
 	}
 
-	result, err := serializeMany(supabaseData)
+	result, err := r.serializeManySupabaseDataToModel(supabaseData)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/supabase-users-repository.go
+++ b/internal/adapters/supabase-users-repository.go
@@ -138,7 +138,7 @@ func (r *SupabaseUsersRepository) Create(input ports.CreateUserInput) (string, e
 func (r *SupabaseUsersRepository) FindById(id string, where myTypes.Where) (*models.UserModel, error) {
 	var supabaseData map[string]interface{}
 
-	query := r.client.DB.From("users").Select("*").Single().Eq("id", id)
+	query := r.client.DB.From("users").Select("*", "user_stats(*, tiers(*))").Single().Eq("id", id)
 
 	if len(where) > 0 {
 		for column, filter := range where {

--- a/internal/entities/tier.go
+++ b/internal/entities/tier.go
@@ -8,7 +8,7 @@ type Tier struct {
 	Name              string        `json:"name"`
 	MinimalExperience uint          `json:"minimal_experience"`
 	LimitExperience   uint          `json:"limit_experience"`
-	PreviousTier      *PreviousTier `json:"previous_tier"`
+	PreviousTier      *PreviousTier `json:"previous_tier",omitempty`
 }
 
 type PreviousTier struct {
@@ -18,18 +18,26 @@ type PreviousTier struct {
 	LimitExperience   uint   `json:"limit_experience"`
 }
 
-func BuildTierFromModel(model models.TierModel) *Tier {
+func BuildTierFromModel(model *models.TierModel) *Tier {
+	if model == nil {
+		return nil
+	}
+
 	return &Tier{
 		Id:                model.Id,
 		PreviousTierId:    model.PreviousTierId,
 		Name:              model.Name,
 		MinimalExperience: model.MinimalExperience,
 		LimitExperience:   model.LimitExperience,
-		PreviousTier:      BuildPreviousTierFromModel(*model.PreviousTier),
+		PreviousTier:      BuildPreviousTierFromModel(model.PreviousTier),
 	}
 }
 
-func BuildPreviousTierFromModel(model models.TierModel) *PreviousTier {
+func BuildPreviousTierFromModel(model *models.TierModel) *PreviousTier {
+	if model == nil {
+		return nil
+	}
+
 	return &PreviousTier{
 		Id:                model.Id,
 		Name:              model.Name,
@@ -41,7 +49,7 @@ func BuildPreviousTierFromModel(model models.TierModel) *PreviousTier {
 func BuildTiersFromModels(models []models.TierModel) []Tier {
 	var tiers []Tier
 	for _, model := range models {
-		tier := BuildTierFromModel(model)
+		tier := BuildTierFromModel(&model)
 		tiers = append(tiers, *tier)
 	}
 	return tiers

--- a/internal/entities/tier.go
+++ b/internal/entities/tier.go
@@ -3,18 +3,38 @@ package entities
 import "github.com/afmireski/garchop-api/internal/models"
 
 type Tier struct {
-	Id uint `json:"id"`
-	Name string `json:"name"`
-	MinimalExperience uint `json:"minimal_experience"`
-	LimitExperience uint `json:"limit_experience"`
+	Id                uint          `json:"id"`
+	PreviousTierId    uint          `json:"previous_tier_id"`
+	Name              string        `json:"name"`
+	MinimalExperience uint          `json:"minimal_experience"`
+	LimitExperience   uint          `json:"limit_experience"`
+	PreviousTier      *PreviousTier `json:"previous_tier"`
 }
 
-func BuildTierFromModel(model models.TierModel) Tier {
-	return Tier{
-		Id: model.Id,
-		Name: model.Name,
+type PreviousTier struct {
+	Id                uint   `json:"id"`
+	Name              string `json:"name"`
+	MinimalExperience uint   `json:"minimal_experience"`
+	LimitExperience   uint   `json:"limit_experience"`
+}
+
+func BuildTierFromModel(model models.TierModel) *Tier {
+	return &Tier{
+		Id:                model.Id,
+		PreviousTierId:    model.PreviousTierId,
+		Name:              model.Name,
 		MinimalExperience: model.MinimalExperience,
-		LimitExperience: model.LimitExperience,
+		LimitExperience:   model.LimitExperience,
+		PreviousTier:      BuildPreviousTierFromModel(*model.PreviousTier),
+	}
+}
+
+func BuildPreviousTierFromModel(model models.TierModel) *PreviousTier {
+	return &PreviousTier{
+		Id:                model.Id,
+		Name:              model.Name,
+		MinimalExperience: model.MinimalExperience,
+		LimitExperience:   model.LimitExperience,
 	}
 }
 
@@ -22,7 +42,7 @@ func BuildTiersFromModels(models []models.TierModel) []Tier {
 	var tiers []Tier
 	for _, model := range models {
 		tier := BuildTierFromModel(model)
-		tiers = append(tiers, tier)
+		tiers = append(tiers, *tier)
 	}
 	return tiers
 }

--- a/internal/entities/user-stats.go
+++ b/internal/entities/user-stats.go
@@ -6,14 +6,18 @@ type UserStats struct {
 	UserId     string `json:"user_id"`
 	TierId     uint   `json:"tier_id"`
 	Experience uint   `json:"experience"`
-	Tier       *Tier  `json:"tiers"`
+	Tier       *Tier  `json:"tiers",omitempty`
 }
 
-func BuildUserStatsFromModel(model models.UserStatsModel) *UserStats {
+func BuildUserStatsFromModel(model *models.UserStatsModel) *UserStats {
+	if model == nil {
+		return nil
+	}
+
 	return &UserStats{
 		UserId:     model.UserId,
 		TierId:     model.TierId,
 		Experience: model.Experience,
-		Tier:       BuildTierFromModel(*model.Tier),
+		Tier:       BuildTierFromModel(model.Tier),
 	}
 }

--- a/internal/entities/user-stats.go
+++ b/internal/entities/user-stats.go
@@ -1,0 +1,19 @@
+package entities
+
+import "github.com/afmireski/garchop-api/internal/models"
+
+type UserStats struct {
+	UserId     string `json:"user_id"`
+	TierId     uint   `json:"tier_id"`
+	Experience uint   `json:"experience"`
+	Tier       *Tier  `json:"tiers"`
+}
+
+func BuildUserStatsFromModel(model models.UserStatsModel) *UserStats {
+	return &UserStats{
+		UserId:     model.UserId,
+		TierId:     model.TierId,
+		Experience: model.Experience,
+		Tier:       BuildTierFromModel(*model.Tier),
+	}
+}

--- a/internal/entities/users.go
+++ b/internal/entities/users.go
@@ -14,12 +14,13 @@ const (
 )
 
 type User struct {
-	Id        string
-	Name      string
-	Email     string
-	Phone     string
-	BirthDate time.Time
-	Role      UserRoleEnum
+	Id        string       `json:"id"`
+	Name      string       `json:"name"`
+	Email     string       `json:"email"`
+	Phone     string       `json:"phone"`
+	BirthDate time.Time    `json:"birth_date"`
+	Role      UserRoleEnum `json:"role"`
+	Status    *UserStats   `json:"status",omitempty`
 }
 
 func NewUser(id string, name string, email string, phone string, birthDate time.Time, role string) *User {
@@ -30,6 +31,18 @@ func NewUser(id string, name string, email string, phone string, birthDate time.
 		Phone:     phone,
 		BirthDate: birthDate,
 		Role:      UserRoleEnum(role),
+	}
+}
+
+func BuildUserFromModel(model models.UserModel) *User {
+	return &User{
+		Id:        model.Id,
+		Name:      model.Name,
+		Email:     model.Email,
+		Phone:     model.Phone,
+		BirthDate: model.BirthDate,
+		Role:      UserRoleEnum(model.Role),
+		Status:    BuildUserStatsFromModel(*model.Stats),
 	}
 }
 

--- a/internal/entities/users.go
+++ b/internal/entities/users.go
@@ -34,7 +34,11 @@ func NewUser(id string, name string, email string, phone string, birthDate time.
 	}
 }
 
-func BuildUserFromModel(model models.UserModel) *User {
+func BuildUserFromModel(model *models.UserModel) *User {
+	if model == nil {
+		return nil
+	}
+
 	return &User{
 		Id:        model.Id,
 		Name:      model.Name,
@@ -42,7 +46,7 @@ func BuildUserFromModel(model models.UserModel) *User {
 		Phone:     model.Phone,
 		BirthDate: model.BirthDate,
 		Role:      UserRoleEnum(model.Role),
-		Status:    BuildUserStatsFromModel(*model.Stats),
+		Status:    BuildUserStatsFromModel(model.Stats),
 	}
 }
 

--- a/internal/models/tiers-model.go
+++ b/internal/models/tiers-model.go
@@ -4,10 +4,12 @@ import "time"
 
 type TierModel struct {
 	Id                uint       `json:"id"`
+	PreviousTierId    uint       `json:"previous_tier_id"`
 	Name              string     `json:"name"`
 	MinimalExperience uint       `json:"minimal_experience"`
 	LimitExperience   uint       `json:"limit_experience"`
 	CreatedAt         time.Time  `json:"created_at"`
 	UpdatedAt         time.Time  `json:"updated_at"`
 	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
+	PreviousTier      *TierModel `json:"previous_tier"`
 }

--- a/internal/models/tiers-model.go
+++ b/internal/models/tiers-model.go
@@ -11,5 +11,5 @@ type TierModel struct {
 	CreatedAt         time.Time  `json:"created_at"`
 	UpdatedAt         time.Time  `json:"updated_at"`
 	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
-	PreviousTier      *TierModel `json:"previous_tier"`
+	PreviousTier      *TierModel `json:"tiers"`
 }

--- a/internal/models/users-model.go
+++ b/internal/models/users-model.go
@@ -22,6 +22,7 @@ type UserModel struct {
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
 	DeletedAt time.Time         `json:"deleted_at"`
+	Status    *UserStatsModel   `json:"stats",omitempty`
 }
 
 func NewUserModel(id string, name string, email string, phone string, birthDate time.Time, role UserModelRoleEnum,

--- a/internal/models/users-model.go
+++ b/internal/models/users-model.go
@@ -22,11 +22,11 @@ type UserModel struct {
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
 	DeletedAt time.Time         `json:"deleted_at"`
-	Status    *UserStatsModel   `json:"stats",omitempty`
+	Stats     *UserStatsModel   `json:"user_stats",omitempty`
 }
 
 func NewUserModel(id string, name string, email string, phone string, birthDate time.Time, role UserModelRoleEnum,
-	createdAt time.Time, updatedAt time.Time, deletedAt time.Time) *UserModel {
+	createdAt time.Time, updatedAt time.Time, deletedAt time.Time, stats *UserStatsModel) *UserModel {
 	return &UserModel{
 		Id:        id,
 		Name:      name,
@@ -37,5 +37,6 @@ func NewUserModel(id string, name string, email string, phone string, birthDate 
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
 		DeletedAt: deletedAt,
+		Stats:     stats,
 	}
 }

--- a/internal/services/tiers-service.go
+++ b/internal/services/tiers-service.go
@@ -46,7 +46,7 @@ func (s *TiersService) FindById(id int) (*entities.Tier, *customErrors.InternalE
 	} else if data == nil {
 		return nil, customErrors.NewInternalError("tier not found", 404, []string{})
 	}
-	response := entities.BuildTierFromModel(*data)
+	response := entities.BuildTierFromModel(data)
 
 	return response, nil
 }

--- a/internal/services/tiers-service.go
+++ b/internal/services/tiers-service.go
@@ -48,5 +48,5 @@ func (s *TiersService) FindById(id int) (*entities.Tier, *customErrors.InternalE
 	}
 	response := entities.BuildTierFromModel(*data)
 
-	return &response, nil
+	return response, nil
 }

--- a/internal/services/users-service.go
+++ b/internal/services/users-service.go
@@ -190,7 +190,7 @@ func (s *UsersService) GetUserById(id string) (*entities.User, *customErrors.Int
 		return nil, customErrors.NewInternalError("user not found", 404, []string{})
 	}
 
-	return entities.NewUser(response.Id, response.Name, response.Email, response.Phone, response.BirthDate, string(response.Role)), nil
+	return entities.BuildUserFromModel(response), nil
 }
 
 func (s *UsersService) GetUsers(where myTypes.Where) ([]entities.User, *customErrors.InternalError) {


### PR DESCRIPTION
## Descrição
Nessa Issue foram adicionadas informações de status ao listar informações de um único usuário.


## Contexto
- **motivação: Incluir informações de status ao listar informações de um usuário** <!--- Sumarize numa frase o motivo da PR -->

closes #56 <!--N | O número da Issue com que a PR se relaciona, por exemplo #1 -->

<!-- Providência qualquer detalhe extra que achar importante -->

## Como testar
1. Requisite para a rota `/users/:id`

### Escritor
<!-- Especifique as ações que deverão ser feitas durante o teste -->
- [x] As informações de status são retornadas.
- [x] Se um usuário não tiver informação de status, o campo fica null.
- [x] Os dados são serializados corretamente.

### Tester
<!-- Cópia das ações anteriores, essa para a pessoa que testar saber onde ela parou nos testes -->
- [x] As informações de status são retornadas.
- [x] Se um usuário não tiver informação de status, o campo fica null.
- [x] Os dados são serializados corretamente.

## Natureza da alteração
<!-- Indica o tipo de alteração que foi feita -->
- [ ] Nova Feature.
- [ ] Correção de BUG.
- [x] Refatoração de Código.