### PR TITLE
#57 - Implementar cadastro de recompensas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 * [#57](https://github.com/afmireski/garchop-api/issues/57) - Implementar cadastro de recompensas
-* [#58](https://github.com/afmireski/garchop-api/issues/56) - Implementar listagem geral de recompensas
+* [#58](https://github.com/afmireski/garchop-api/issues/58) - Implementar listagem geral de recompensas
 * [#51](https://github.com/afmireski/garchop-api/issues/50) - Atualizar a experiência de usuário ao comprar Pokémons
 * [#56](https://github.com/afmireski/garchop-api/issues/56) - Trazer dados de Status do Usuário na hora de listar o perfil do usuário
 * [#45](https://github.com/afmireski/garchop-api/issues/45) - Implementar listagem do histórico de compras do usuário

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [#57](https://github.com/afmireski/garchop-api/issues/57) - Implementar cadastro de recompensas
 * [#52](https://github.com/afmireski/garchop-api/issues/52) - Obter Status do Usuário
 * [#47](https://github.com/afmireski/garchop-api/issues/47) - Implementar autenticação
-* [#58](https://github.com/afmireski/garchop-api/issues/56) - Implementar listagem geral de recompensas
+* [#58](https://github.com/afmireski/garchop-api/issues/58) - Implementar listagem geral de recompensas
 * [#51](https://github.com/afmireski/garchop-api/issues/50) - Atualizar a experiência de usuário ao comprar Pokémons
 * [#56](https://github.com/afmireski/garchop-api/issues/56) - Trazer dados de Status do Usuário na hora de listar o perfil do usuário
 * [#45](https://github.com/afmireski/garchop-api/issues/45) - Implementar listagem do histórico de compras do usuário

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* [#57](https://github.com/afmireski/garchop-api/issues/57) - Implementar cadastro de recompensas
 * [#58](https://github.com/afmireski/garchop-api/issues/56) - Implementar listagem geral de recompensas
 * [#51](https://github.com/afmireski/garchop-api/issues/50) - Atualizar a experiência de usuário ao comprar Pokémons
 * [#56](https://github.com/afmireski/garchop-api/issues/56) - Trazer dados de Status do Usuário na hora de listar o perfil do usuário

--- a/internal/adapters/supabase-rewards-repository.go
+++ b/internal/adapters/supabase-rewards-repository.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/afmireski/garchop-api/internal/models"
+	"github.com/afmireski/garchop-api/internal/ports"
 	"github.com/nedpals/supabase-go"
 
 	myTypes "github.com/afmireski/garchop-api/internal/types"
@@ -50,8 +51,16 @@ func (r *SupabaseRewardsRepository) serializeManyToModel(supabaseData []myTypes.
 	return modelData, nil
 }
 
-func (r *SupabaseRewardsRepository) Create(input myTypes.Any) (string, error) {
-	panic("implement me")
+func (r *SupabaseRewardsRepository) Create(input ports.CreateRewardInput) (string, error) {
+	var supabaseData []myTypes.AnyMap
+
+	err := r.client.DB.From("rewards").Insert(input).Execute(&supabaseData)
+	
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
 }
 
 func (r *SupabaseRewardsRepository) FindAll(where myTypes.Where) ([]models.RewardModel, error) {

--- a/internal/ports/rewards-repository.port.go
+++ b/internal/ports/rewards-repository.port.go
@@ -1,12 +1,24 @@
 package ports
 
 import (
+	"encoding/json"
+
 	"github.com/afmireski/garchop-api/internal/models"
 	myTypes "github.com/afmireski/garchop-api/internal/types"
+	"github.com/afmireski/garchop-api/internal/types/enums"
 )
 
 type RewardsRepositoryPort interface {
-	Create(input myTypes.Any) (string, error)	
+	Create(input CreateRewardInput) (string, error)
 	FindAll(where myTypes.Where) ([]models.RewardModel, error)
 	Delete(id string, where myTypes.Where) error
+}
+
+type CreateRewardInput struct {
+	TierId             uint                `json:"tier_id"`
+	Name               string              `json:"name"`
+	Description        string              `json:"description"`
+	ExperienceRequired uint                `json:"experience_required"`
+	Type               enums.PrizeTypeEnum `json:"prize_type"`
+	Prize              json.RawMessage     `json:"prize"`
 }

--- a/internal/services/rewards-service.go
+++ b/internal/services/rewards-service.go
@@ -50,9 +50,9 @@ func (s *RewardsService) NewReward(input myTypes.NewRewardInput) *customErrors.I
 	return nil
 }
 
-func (r *RewardsService) ListAllRewards() ([]entities.Reward, *customErrors.InternalError) {
+func (s *RewardsService) ListAllRewards() ([]entities.Reward, *customErrors.InternalError) {
 
-	repositoryData, err := r.rewardsRepository.FindAll(myTypes.Where{})
+	repositoryData, err := s.rewardsRepository.FindAll(myTypes.Where{})
 
 	if err != nil {
 		return nil, customErrors.NewInternalError("a failure occurred when try to find the rewards", 500, []string{err.Error()})

--- a/internal/services/rewards-service.go
+++ b/internal/services/rewards-service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"github.com/afmireski/garchop-api/internal/entities"
 	"github.com/afmireski/garchop-api/internal/ports"
+	"github.com/afmireski/garchop-api/internal/validators"
 
 	customErrors "github.com/afmireski/garchop-api/internal/errors"
 	myTypes "github.com/afmireski/garchop-api/internal/types"
@@ -16,6 +17,37 @@ func NewRewardsService(rewardsRepository ports.RewardsRepositoryPort) *RewardsSe
 	return &RewardsService{
 		rewardsRepository: rewardsRepository,
 	}
+}
+
+func validateNewRewardInput(input myTypes.NewRewardInput) *customErrors.InternalError {
+	if !validators.IsValidNumericId(input.TierId) {
+		return customErrors.NewInternalError("invalid tier id", 400, []string{})
+	}
+
+	return nil
+}
+
+func (s *RewardsService) NewReward(input myTypes.NewRewardInput) *customErrors.InternalError {
+	if inputErr := validateNewRewardInput(input); inputErr != nil {
+		return inputErr
+	}
+
+	data := ports.CreateRewardInput{
+		TierId:             input.TierId,
+		Name:               input.Name,
+		Description:        input.Description,
+		ExperienceRequired: input.ExperienceRequired,
+		Type:               input.Type,
+		Prize:              input.Prize,
+	}
+
+	_, err := s.rewardsRepository.Create(data)
+
+	if err != nil {
+		return customErrors.NewInternalError("a failure occurred when trying to create a reward", 500, []string{})
+	}
+
+	return nil
 }
 
 func (r *RewardsService) ListAllRewards() ([]entities.Reward, *customErrors.InternalError) {

--- a/internal/services/rewards-service.go
+++ b/internal/services/rewards-service.go
@@ -44,7 +44,7 @@ func (s *RewardsService) NewReward(input myTypes.NewRewardInput) *customErrors.I
 	_, err := s.rewardsRepository.Create(data)
 
 	if err != nil {
-		return customErrors.NewInternalError("a failure occurred when trying to create a reward", 500, []string{})
+		return customErrors.NewInternalError("a failure occurred when trying to create a reward", 500, []string{err.Error()})
 	}
 
 	return nil

--- a/internal/types/input-types.go
+++ b/internal/types/input-types.go
@@ -1,6 +1,11 @@
 package types
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/afmireski/garchop-api/internal/types/enums"
+)
 
 type NewUserInput struct {
 	Name            string     `json:"name"`
@@ -42,4 +47,13 @@ type AddItemToCartBody struct {
 type RemoveItemFromCartInput struct {
 	ItemId string `json:"item_id"`
 	CartId string `json:"cart_id"`
+}
+
+type NewRewardInput struct {
+	TierId             uint                `json:"tier_id"`
+	Name               string              `json:"name"`
+	Description        string              `json:"description"`
+	ExperienceRequired uint                `json:"experience_required"`
+	Type               enums.PrizeTypeEnum `json:"prize_type"`
+	Prize              json.RawMessage     `json:"prize"`
 }

--- a/internal/validators/basic-validators.go
+++ b/internal/validators/basic-validators.go
@@ -25,7 +25,7 @@ func IsValidUuid(id string) bool {
 	return err == nil
 }
 
-func IsValidNumericId(id int) bool {
+func IsValidNumericId[T int | uint](id T) bool {
 	return id > 0
 }
 

--- a/internal/web/controllers/rewards-controller.go
+++ b/internal/web/controllers/rewards-controller.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 
+	customErrors "github.com/afmireski/garchop-api/internal/errors"
 	"github.com/afmireski/garchop-api/internal/services"
+	myTypes "github.com/afmireski/garchop-api/internal/types"
 )
 
 type RewardsController struct {
@@ -15,6 +17,31 @@ func NewRewardsController(service *services.RewardsService) *RewardsController {
 	return &RewardsController{
 		service: service,
 	}
+}
+
+func (c *RewardsController) NewReward(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var input myTypes.NewRewardInput
+
+	err := json.NewDecoder(r.Body).Decode(&input)
+
+	if err != nil {
+		err := customErrors.NewInternalError("fail on deserialize request body", 400, []string{})
+		w.WriteHeader(err.HttpCode)
+		json.NewEncoder(w).Encode(err)
+		return
+	}
+
+	serviceErr := c.service.NewReward(input)
+
+	if serviceErr != nil {
+		w.WriteHeader(serviceErr.HttpCode)
+		json.NewEncoder(w).Encode(serviceErr)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
 
 func (c *RewardsController) ListAllRewards(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/routers/rewards-router.go
+++ b/internal/web/routers/rewards-router.go
@@ -7,4 +7,5 @@ import (
 
 func SetupRewardsRouter(router *chi.Mux, controller *controllers.RewardsController) {
 	router.Get("/rewards", controller.ListAllRewards)	
+	router.Post("/rewards/new", controller.NewReward)
 }


### PR DESCRIPTION
## Descrição
[Conforme um cliente sobe seu nível, ele pode ter acesso a diversas recompensas. Todavia, é necessário antes cadastrá-las no sistema.](https://github.com/afmireski/garchop-api/issues/57)

## Contexto
- **motivação:** Implementar o cadastro de recompensas.

closes #57

## Como testar
Requisite para a rota: ``POST /rewards/new``

Exemplo de body:
```
{
  "tier_id": 1,
  "name": "Bulbasaur",
  "description": "A cool grass pokemon",
  "experience_required": 10,
  "prize_type": "pokemon",
  "prize": {
    "pokemon_id": "bulbasaur_id"
  }
}
```

### Escritor
- [X] Todas as validações de entrada passaram:
  - [X] Se ``tier_id`` é inválido (menor que um), lança exceção ``400 Bad Request``.
  - [X] Se ``experience_required`` é menor que 0, lança exceção ``400 Bad Request``.
  - [X] Se ``prize`` não for um json válido, lança exceção ``400 Bad Request``.
  - [X] Se ``prize_type`` não for um tipo válido, lança exceção ``400 Bad Request``.
  - [X] Se tudo ocorreu certo, os dados são persistidos e retorna ``201 Created``.

### Tester
- [x] Todas as validações de entrada passaram:
  - [x] Se ``tier_id`` é inválido (menor que um), lança exceção ``400 Bad Request``.
  - [x] Se ``experience_required`` é menor que 0, lança exceção ``400 Bad Request``.
  - [x] Se ``prize`` não for um json válido, lança exceção ``400 Bad Request``.
  - [x] Se ``prize_type`` não for um tipo válido, lança exceção ``400 Bad Request``.
  - [x] Se tudo ocorreu certo, os dados são persistidos e retorna ``201 Created``.

## Natureza da alteração
- [X] Nova Feature.
- [ ] Correção de BUG.
- [ ] Refatoração de Código.