### PR TITLE
#68 - [BUG]: Informações detalhadas de um pokémon não aparecem na compra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fix
+* [#68](https://github.com/afmireski/garchop-api/issues/68) - [BUG]: Informações detalhadas de um pokémon não aparecem na compra
+
 ### Added
 * [#61](https://github.com/afmireski/garchop-api/issues/61) - Implementar obtenção de recompensas por usuários
     * Removendo parâmetros `user_id` das rotas e substituindo por obtenção via `token`

--- a/internal/adapters/supabase-purchase-repository.adapter.go
+++ b/internal/adapters/supabase-purchase-repository.adapter.go
@@ -94,7 +94,7 @@ func (r *SupabasePurchaseRepository) FindById(id string, where myTypes.Where) (*
 func (r *SupabasePurchaseRepository) FindAll(where myTypes.Where) ([]models.PurchaseModel, error) {
 	var supabaseData []myTypes.AnyMap
 
-	query := r.supabaseClient.DB.From("purchases").Select("*", "items(*)")
+	query := r.supabaseClient.DB.From("purchases").Select("*", "items(*, pokemons(*, pokemon_types(*, types(*)), tiers(*)))")
 
 	if len(where) > 0 {
 		for column, filter := range where {

--- a/internal/web/controllers/purchase-controller.go
+++ b/internal/web/controllers/purchase-controller.go
@@ -21,6 +21,8 @@ func NewPurchaseController(service *services.PurchasesService) *PurchaseControll
 }
 
 func (c *PurchaseController) FinishPurchase(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
 	userId := r.Header.Get("User-Id")
 
 	var body myTypes.FinishPurchaseBody
@@ -48,6 +50,8 @@ func (c *PurchaseController) FinishPurchase(w http.ResponseWriter, r *http.Reque
 }
 
 func (c *PurchaseController) GetPurchasesByUser(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
 	userId := r.Header.Get("User-Id")
 
 	purchases, err := c.service.GetPurchasesByUser(userId)


### PR DESCRIPTION
## Contexto
- **motivação: Retornar informações de pokémons na listagem de compras** 

closes #68 

<!-- Providência qualquer detalhe extra que achar importante -->

## Como testar
1. Logar no sistema
2. Requisitar `/purchases`

### Escritor
<!-- Especifique as ações que deverão ser feitas durante o teste -->
- [x] As informações de Pokémon estão sendo retornadas corretamente.

### Tester
<!-- Cópia das ações anteriores, essa para a pessoa que testar saber onde ela parou nos testes -->
- [x] As informações de Pokémon estão sendo retornadas corretamente.

## Natureza da alteração
<!-- Indica o tipo de alteração que foi feita -->
- [ ] Nova Feature.
- [x] Correção de BUG.
- [ ] Refatoração de Código.